### PR TITLE
bug fix -- with iq message sending , after 'error' or 'result' has co…

### DIFF
--- a/src/ecomponent.erl
+++ b/src/ecomponent.erl
@@ -165,6 +165,7 @@ handle_info(
         type_attr=Type, 
         raw_packet=IQ, 
         from={Node, Domain, _}=From}=ReceivedPacket,
+    NewState = State#state{resend = false}, % waited response has come
     NS = exmpp_iq:get_payload_ns_as_atom(IQ),
     ecomponent_metrics:notify_throughput_iq(in, Type, NS),
     JIDBin = list_to_binary(exmpp_jid:to_list(Node, Domain)),
@@ -183,10 +184,10 @@ handle_info(
                 process_run(iq_handler, pre_process_iq, [
                     Type, IQ, NS, From, Features, Info, ServerID])
         end,
-        {noreply, State, get_countdown(State)};
+        {noreply, NewState, 100};
     true ->
         ecomponent_metrics:notify_dropped_iq(Type, NS),
-        {noreply, State, get_countdown(State)}
+        {noreply, NewState, 100}
     end;
 
 handle_info(


### PR DESCRIPTION
Hi Manuel, 

This is for bug fix -- "with iq message sending , after 'error' or 'result' has come , ecomponent still keeps trying to send message"

I fixed only iq processing , not sure whether i have broken ecomponent specification. If it is accepted , i will fix presence and message handling.

How to reproduce the problem:
~~~~~~~~~~~~~~~~~~~~~~~~~
1) on component derived from ecomponent use `ecomponent:send(Packet, NS, ?MODULE, true)`. Make sure the recipient exists and reply with error or result
2) in component derived from ecomponent have `response` signal handling , like below :
 loop() ->
    receive 
        #response{params=Params=#params{type=Type}}
                when Type =:= "result"
                orelse Type =:= "error" ->
            process_confirmation(Params),
            loop();
            ........
    end.
3) make sure component derived from ecomponent  receives response and handle it.
4) Observe the PROBLEM -- after 'error' or 'result' has come , ecomponent still keeps trying to send message that is indicated with the following log :
```
18:18:43.409 [warning] Max tries exceeded for: {matching,<<"f4f9a6cf-5821-4b0f-8e39-eaba12e7242e">>,'jongla:official:master:update:channel',officdepot,3,{xmlel,'jabber:component:accept',[],iq,[{xmlattr,undefined,<<"to">>,<<"official.im.jongla.im">>},{xmlattr ....
```