### PR TITLE
ecomponent: changing dependencies to fix compatibility with OTP-22 an…

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,14 +1,14 @@
 {erl_opts, [{parse_transform, lager_transform}, debug_info, {src_dirs, ["src"]}]}.
 
 {deps, [
-    {exmpp, ".*", {git, "git://github.com/altenwald/exmpp.git", "master"}},
+    {exmpp, ".*", {git, "git://github.com/Teknogrebo/exmpp.git", "rebar"}},
     {lager, ".*", {git, "git://github.com/basho/lager.git", "1.2.1"}},
     {syslog, ".*", {git, "git://github.com/nivertech/erlang-syslog", "ori_070812"}},
     {uuid, ".*", {git, "git://github.com/avtobiff/erlang-uuid.git", "v0.3.3"}},
     {folsom, ".*", {git, "git://github.com/boundary/folsom.git", {tag, "0.7.4"}}},
 
     % only for test, don't include them in reltool
-    {meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.4"}},
+    {meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.13"}},
 
     %% documentation
     {edown, ".*", {git, "https://github.com/uwiger/edown", master}}


### PR DESCRIPTION
Hello Manuel,

This is dependencies update to make ecomponent compatible with openssl 1.1.1 and OTP22

Regards,
Igor